### PR TITLE
bump nugets for Microsoft.Azure.Functions.Worker to 1.9.0

### DIFF
--- a/samples/Quickstart/src/QuickstartSample.csproj
+++ b/samples/Quickstart/src/QuickstartSample.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.9.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <!-- Default to version 1.0.0 if SdkVersion is not set -->
-  <ItemGroup Condition="'$(SdkVersion)' == ''" >
+  <ItemGroup Condition="'$(SdkVersion)' == ''">
     <PackageReference Include="Microsoft.AzureHealth.DataServices.Core" Version="1.0.0" />
   </ItemGroup>
 
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <!-- If neither of the above, read version from SdkVersion  -->
-  <ItemGroup Condition="'$(SdkVersion)' != '' And '$(SdkVersion)' != 'local'" >
+  <ItemGroup Condition="'$(SdkVersion)' != '' And '$(SdkVersion)' != 'local'">
     <PackageReference Include="Microsoft.AzureHealth.DataServices.Core" Version="$(SdkVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.AzureHealth.DataServices.Core/Microsoft.AzureHealth.DataServices.Core.csproj
+++ b/src/Microsoft.AzureHealth.DataServices.Core/Microsoft.AzureHealth.DataServices.Core.csproj
@@ -44,12 +44,12 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.3.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.4.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.9.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="6.0.9">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description
Bumping Microsoft.Azure.Functions.Worker v1.8.0  to v1.9.0 

## Related issues
Vulnerability found in  Microsoft.Azure.Functions.Worker v1.8.0  regarding Google ProtoBuf.  We are bumping NuGet to v1.9.0 to remove it.

## Testing
All tests pass.

## Reviewer Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Tag the PR with the type of update: **Bug**, **New-Sample**, **Enhancement**, or **New-Feature**
- [ ] CI is green before merge
