### PR TITLE
Switched to using AsyncKeyedLock

### DIFF
--- a/src/Microsoft.AzureHealth.DataServices.Caching/Microsoft.AzureHealth.DataServices.Caching.csproj
+++ b/src/Microsoft.AzureHealth.DataServices.Caching/Microsoft.AzureHealth.DataServices.Caching.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.0.5" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.1.0" />
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />

--- a/src/Microsoft.AzureHealth.DataServices.Caching/Microsoft.AzureHealth.DataServices.Caching.csproj
+++ b/src/Microsoft.AzureHealth.DataServices.Caching/Microsoft.AzureHealth.DataServices.Caching.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.1.0" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.1.1" />
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />

--- a/src/Microsoft.AzureHealth.DataServices.Caching/Microsoft.AzureHealth.DataServices.Caching.csproj
+++ b/src/Microsoft.AzureHealth.DataServices.Caching/Microsoft.AzureHealth.DataServices.Caching.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.0.5" />
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />


### PR DESCRIPTION
Switched to using AsyncKeyedLock, which provides better performance, reduced allocations and does not retain items in the dictionary.