### PR TITLE
**New-Feature** Add APIM to Toolkit Quickstart and Update Toolkit Quickstart to disable Basic Auth

### DIFF
--- a/samples/Quickstart/README.md
+++ b/samples/Quickstart/README.md
@@ -37,7 +37,8 @@ This quickstart will create the below resources. These will be used both for loc
 - Azure Health Data Services workspace
 - FHIR Service
 - Function App (and associated storage account)
-- Log Analytics Workspace (for FHIR Service and Function App logs)
+- APIM - [Azure API Management](https://learn.microsoft.com/azure/api-management/) (for Function App and Fhir Service)
+- Log Analytics Workspace (for FHIR Service, Function App and APIM logs)
 - Application Insights (for monitoring your custom operation)
 
 ### Deploy Quickstart
@@ -56,13 +57,16 @@ This quickstart will create the below resources. These will be used both for loc
     - `existingAzureHealthDataServicesWorkspaceName`: The name of your existing Azure Health Data Services workspace.
     - `existingFhirServiceName`: The name of your existing FHIR Service.
 
-4. Next, you need to provision your Azure resources to run the sample with azd. If you are creating a new FHIR Service, this deploy may take 20 minutes.
+4. By default, APIM is enabled for use. if you do not want to use APIM then pass `useAPIM` value as false Or  Open `infra/main.parameters.json` in a code editor and set the value of the parameter named `useAPIM` to false.
+ 
+
+5. Next, you need to provision your Azure resources to run the sample with azd. If you are creating a new FHIR Service, this deploy may take 20 minutes.
 
     ```dotnetcli
     azd provision
     ```
 
-5. To deploy your code (this can be done after local testing), run the deploy command.
+6. To deploy your code (this can be done after local testing), run the deploy command.
 
     ```dotnetcli
     azd deploy
@@ -92,8 +96,17 @@ This quickstart will create the below resources. These will be used both for loc
 1. Once you are ready to deploy to Azure, we can use azd. Run `azd deploy` from your terminal or command prompt.
 2. The command will output ae endpoint for your function app. Copy this.
 3. Test the endpoint by going to `<Endpoint>/Patient` in your browser or API testing tool.
+4. For APIM endpoint, get APIM Gateway URL from section [Get the deployment details](##get-the-deployment-details) and test endpoint in API testing tool.
+
+## Get the deployment details
+
+ - Run the below command to get the deployed APIM Gateway URL variable named `APIM_GatewayUrl`.
+    ```
+     azd get-values
+    ```
 
 ## Usage details
+#### Quickstart function app
 
 - `Program.cs` outlines how we can use Azure Function for Simple custom operation using various types of services like authenticator, headers and filters.
   - UseAuthenticator() Used for accessing Azure resources, it uses azure default credentials.
@@ -109,3 +122,11 @@ This quickstart will create the below resources. These will be used both for loc
   - POST: creates new patient record with updated filter data which is given above,to verify the new created record use GET method and pass created id.
   - PUT: it updates the patient data, need to pass patient id,to verify the updated record use GET method and pass updated id.
   - DELETE: used to delete the patient record from FHIR server by passing patient id, to verify the deleted record use GET method and pass deleted id.
+
+
+#### APIM- Azure API Management
+
+- APIM supports the complete API lifecycle, this template is prepared to use APIM for Fhir Service and Function App endpoints.
+- in given APIM all the operations related to Patient are routed to QuickStart function app and for Fhir Service endpoints we have four methods like GET, POST, PUT, DELETE.
+
+ 

--- a/samples/Quickstart/infra/apiManagement/apim-api.bicep
+++ b/samples/Quickstart/infra/apiManagement/apim-api.bicep
@@ -1,0 +1,239 @@
+param name string
+
+@description('Resource name to uniquely identify this API within the API Management service instance')
+@minLength(1)
+param apiName string
+
+@description('The Display Name of the API')
+@minLength(1)
+@maxLength(300)
+param apiDisplayName string
+
+@description('Description of the API. May include HTML formatting tags.')
+@minLength(1)
+param apiDescription string
+
+@description('Absolute URL of the backend function app for implementing this API.')
+param functionAppUrl string
+
+@description('Default Key of the function app for implementing this API.')
+param functionAppKey string
+
+@description('Absolute URL of the backend Fhir Service for implementing this API.')
+param fhirServiceUrl string
+
+param apimServiceLoggerId string
+
+param useAPIM bool
+
+var apiPolicyContent = loadTextContent('policies/apim-api-policy.xml')
+
+var fhirApiPolicyContent = replace(loadTextContent('policies/apim-fhir-api-policy.xml'), '{fhirServiceUrl}', fhirServiceUrl)
+
+var QuickStartPolicyContent = replace(loadTextContent('policies/apim-quickstart-api-policy.xml'), '{functionAppUrl}', functionAppUrl)
+
+var QuickStartPolicy = replace(QuickStartPolicyContent,'{funDefaultKey}',functionAppKey)
+
+resource apimService 'Microsoft.ApiManagement/service@2021-08-01' existing = if(useAPIM) {
+    name: name
+}
+
+resource quickStartApi 'Microsoft.ApiManagement/service/apis@2021-12-01-preview' = if(useAPIM) {
+    name: apiName
+    parent: apimService
+    properties: {
+        description: apiDescription
+        displayName: apiDisplayName
+        apiRevision: 'v1'
+        subscriptionRequired: false
+        serviceUrl: ''
+        protocols: [
+            'https'
+        ]
+        path: ''
+    }
+
+    resource apiPolicy 'policies' = {
+        name: 'policy'
+        properties: {
+            format: 'rawxml'
+            value: apiPolicyContent
+        }
+    }
+
+    resource QuickStartPatientGet 'operations' = {
+        name: 'get-patient'
+        properties: {
+            displayName: 'Patient'
+            method: 'GET'
+            urlTemplate: '/Patient/{id}'
+            templateParameters: [
+                {
+                    name: 'id'
+                    description: 'ID of the Patient'
+                    required: true
+                    type: 'SecureString'
+                }
+            ]
+        }
+
+        resource QuickStartApiPolicy 'policies' = {
+            name: 'policy'
+            properties: {
+                format: 'rawxml'
+                value: QuickStartPolicy
+            }
+        }
+    }
+
+    resource QuickStartPatientPut 'operations' = {
+        name: 'put-patient'
+        properties: {
+            displayName: 'Patient'
+            method: 'PUT'
+            urlTemplate: '/Patient/{id}'
+            templateParameters: [
+                {
+                    name: 'id'
+                    description: 'ID of the Patient'
+                    required: true
+                    type: 'SecureString'
+                }
+            ]
+        }
+
+        resource QuickStartApiPolicy 'policies' = {
+            name: 'policy'
+            properties: {
+                format: 'rawxml'
+                value: QuickStartPolicy
+            }
+        }
+    }
+
+    resource QuickStartPatientDelete 'operations' = {
+        name: 'delete-patient'
+        properties: {
+            displayName: 'Patient'
+            method: 'DELETE'
+            urlTemplate: '/Patient/{id}'
+            templateParameters: [
+                {
+                    name: 'id'
+                    description: 'ID of the Patient'
+                    required: true
+                    type: 'SecureString'
+                }
+            ]
+        }
+
+        resource QuickStartApiPolicy 'policies' = {
+            name: 'policy'
+            properties: {
+                format: 'rawxml'
+                value: QuickStartPolicy
+            }
+        }
+    }
+
+
+    resource QuickStartPatientPost 'operations' = {
+        name: 'post-patient'
+        properties: {
+            displayName: 'Patient'
+            method: 'POST'
+            urlTemplate: '/Patient'
+        }
+
+        resource QuickStartApiPolicy 'policies' = {
+            name: 'policy'
+            properties: {
+                format: 'rawxml'
+                value: QuickStartPolicy
+            }
+        }
+    }
+
+    resource FHIRServerGet 'operations' = {
+        name: 'get-fhir'
+        properties: {
+            displayName: 'FHIR Server'
+            method: 'GET'
+            urlTemplate: '/*'
+        }
+
+        resource fhirApiPolicy 'policies' = {
+            name: 'policy'
+            properties: {
+                format: 'rawxml'
+                value: fhirApiPolicyContent
+            }
+        }
+    }
+
+    resource FHIRServerPost 'operations' = {
+        name: 'post-fhir'
+        properties: {
+            displayName: 'FHIR Server'
+            method: 'POST'
+            urlTemplate: '/*'
+        }
+
+        resource fhirApiPolicy 'policies' = {
+            name: 'policy'
+            properties: {
+                format: 'rawxml'
+                value: fhirApiPolicyContent
+            }
+        }
+    }
+
+    resource FHIRServerPut 'operations' = {
+        name: 'put-fhir'
+        properties: {
+            displayName: 'FHIR Server'
+            method: 'PUT'
+            urlTemplate: '/*'
+        }
+
+        resource fhirApiPolicy 'policies' = {
+            name: 'policy'
+            properties: {
+                format: 'rawxml'
+                value: fhirApiPolicyContent
+            }
+        }
+    }
+
+    resource FHIRServerDelete 'operations' = {
+        name: 'delete-fhir'
+        properties: {
+            displayName: 'FHIR Server'
+            method: 'DELETE'
+            urlTemplate: '/*'
+        }
+
+        resource fhirApiPolicy 'policies' = {
+            name: 'policy'
+            properties: {
+                format: 'rawxml'
+                value: fhirApiPolicyContent
+            }
+        }
+    }
+
+    resource smartApiDiagnostics 'diagnostics' = {
+        name: 'applicationinsights'
+        properties: {
+            alwaysLog: 'allErrors'
+            httpCorrelationProtocol: 'W3C'
+            verbosity: 'information'
+            logClientIp: true
+            loggerId: apimServiceLoggerId
+            sampling: {
+                samplingType: 'fixed'
+                percentage: 100
+            }
+        }
+    }
+}

--- a/samples/Quickstart/infra/apiManagement/apim.bicep
+++ b/samples/Quickstart/infra/apiManagement/apim.bicep
@@ -1,0 +1,79 @@
+param apiManagementServiceName string
+param location string
+param sku string
+param skuCount int
+param publisherName string
+param publisherEmail string
+param appInsightsInstrumentationKey string
+param useAPIM bool
+
+resource apim 'Microsoft.ApiManagement/service@2021-12-01-preview' = if (useAPIM) {
+  name: apiManagementServiceName
+  location: location
+  sku: {
+    name: sku
+    capacity: skuCount
+  }
+
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    publisherEmail: publisherEmail
+    publisherName: publisherName
+  }
+
+  resource apimLogger 'loggers' = {
+    name: 'appinsights'
+    properties: {
+      loggerType: 'applicationInsights'
+      credentials: {
+        appInsightsInstrumentationKey: appInsightsInstrumentationKey
+        instrumentationKey: appInsightsInstrumentationKey
+      }
+      isBuffered: true
+    }
+  }
+
+  resource apimDiagnostics 'diagnostics' = {
+    name: 'applicationinsights'
+    properties: {
+      alwaysLog: 'allErrors'
+      httpCorrelationProtocol: 'W3C'
+      logClientIp: true
+      loggerId: apimLogger.id
+      sampling: {
+        samplingType: 'fixed'
+        percentage: 100
+      }
+      frontend: {
+        request: {
+          dataMasking: {
+            queryParams: [
+              {
+                value: '*'
+                mode: 'Hide'
+              }
+            ]
+          }
+        }
+      }
+      backend: {
+        request: {
+          dataMasking: {
+            queryParams: [
+              {
+                value: '*'
+                mode: 'Hide'
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+output apimName string = useAPIM ? apim.name:''
+output serviceLoggerId string = useAPIM ? apim::apimLogger.id:''
+

--- a/samples/Quickstart/infra/apiManagement/policies/apim-api-policy.xml
+++ b/samples/Quickstart/infra/apiManagement/policies/apim-api-policy.xml
@@ -1,0 +1,43 @@
+<!--
+    IMPORTANT:
+    - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
+    - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
+    - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
+    - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
+    - To remove a policy, delete the corresponding policy statement from the policy document.
+    - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
+    - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
+    - Policies are applied in the order of their appearance, from the top down.
+    - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
+-->
+<policies>
+    <inbound>
+        <base />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+        <redirect-content-urls />
+        <choose>
+            <when condition="@(context.Response.Headers.ContainsKey("Location") == true)">
+                <set-header name="Location" exists-action="override">
+                    <value>@(context.Response.Headers.GetValueOrDefault("Location","").Replace(context.Request.Url.Host,context.Request.OriginalUrl.Host))</value>
+                </set-header>
+            </when>
+            <otherwise />
+        </choose>
+        <choose>
+            <when condition="@(context.Response.Headers.ContainsKey("Content-Location") == true)">
+                <set-header name="Content-Location" exists-action="override">
+                    <value>@(context.Response.Headers.GetValueOrDefault("Content-Location","").Replace(context.Request.Url.Host,context.Request.OriginalUrl.Host))</value>
+                </set-header>
+            </when>
+            <otherwise />
+        </choose>
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/samples/Quickstart/infra/apiManagement/policies/apim-fhir-api-policy.xml
+++ b/samples/Quickstart/infra/apiManagement/policies/apim-fhir-api-policy.xml
@@ -1,0 +1,27 @@
+<!--
+    IMPORTANT:
+    - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
+    - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
+    - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
+    - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
+    - To remove a policy, delete the corresponding policy statement from the policy document.
+    - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
+    - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
+    - Policies are applied in the order of their appearance, from the top down.
+    - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
+-->
+<policies>
+	<inbound>
+		<base />
+		<set-backend-service base-url="{fhirServiceUrl}" />
+	</inbound>
+	<backend>
+		<base />
+	</backend>
+	<outbound>
+		<base />
+	</outbound>
+	<on-error>
+		<base />
+	</on-error>
+</policies>

--- a/samples/Quickstart/infra/apiManagement/policies/apim-quickstart-api-policy.xml
+++ b/samples/Quickstart/infra/apiManagement/policies/apim-quickstart-api-policy.xml
@@ -1,0 +1,18 @@
+<policies>
+	<inbound>
+		<base />
+		<set-backend-service base-url="{functionAppUrl}" />
+		<set-query-parameter name="code" exists-action="override">
+			<value>{funDefaultKey}</value>
+		</set-query-parameter>
+	</inbound>
+	<backend>
+		<base />
+	</backend>
+	<outbound>
+		<base />
+	</outbound>
+	<on-error>
+		<base />
+	</on-error>
+</policies>

--- a/samples/Quickstart/infra/azureFunction.bicep
+++ b/samples/Quickstart/infra/azureFunction.bicep
@@ -8,65 +8,84 @@ param appTags object = {}
 
 @description('Azure Function required linked storage account')
 resource funcStorageAccount 'Microsoft.Storage/storageAccounts@2021-08-01' = {
-  name: storageAccountName
-  location: location
-  kind: 'StorageV2'
-  sku: {
-    name: 'Standard_LRS'
-  }
-  tags: appTags
+    name: storageAccountName
+    location: location
+    kind: 'StorageV2'
+    sku: {
+        name: 'Standard_LRS'
+    }
+    tags: appTags
 }
 
 @description('App Service used to run Azure Function')
 resource hostingPlan 'Microsoft.Web/serverfarms@2021-03-01' = {
-  name: appServiceName
-  location: location
-  kind: 'functionapp'
-  sku: {
-    name: 'S1'
-  }
-  properties: {}
-  tags: appTags
+    name: appServiceName
+    location: location
+    kind: 'functionapp'
+    sku: {
+        name: 'S1'
+    }
+    properties: {}
+    tags: appTags
 }
 
 @description('Azure Function used to run toolkit compute')
 resource functionApp 'Microsoft.Web/sites@2021-03-01' = {
-  name: functionAppName
-  location: location
-  kind: 'functionapp'
+    name: functionAppName
+    location: location
+    kind: 'functionapp'
 
-  identity: {
-    type: 'SystemAssigned'
-  }
-
-  properties: {
-    httpsOnly: true
-    enabled: true
-    serverFarmId: hostingPlan.id
-    clientAffinityEnabled: false
-    siteConfig: {
-      alwaysOn:true
+    identity: {
+        type: 'SystemAssigned'
     }
-  }
 
-  tags: union(appTags, {
-    'azd-service-name': 'func'
-  })
+    properties: {
+        httpsOnly: true
+        enabled: true
+        serverFarmId: hostingPlan.id
+        clientAffinityEnabled: false
+        siteConfig: {
+            alwaysOn:true
+        }
+    }
+
+    tags: union(appTags, {
+            'azd-service-name': 'func'
+        })
+
+    resource ftpPublishingPolicy 'basicPublishingCredentialsPolicies' = {
+        name: 'ftp'
+        location: location
+        properties: {
+            allow: false
+        }
+    }
+
+    resource scmPublishingPolicy 'basicPublishingCredentialsPolicies' = {
+        name: 'scm'
+        location: location
+        properties: {
+            allow: false
+        }
+    }
 }
 
 resource fhirProxyAppSettings 'Microsoft.Web/sites/config@2020-12-01' = {
-  name: 'appsettings'
-  parent: functionApp
-  properties: union({
-    AzureWebJobsStorage: 'DefaultEndpointsProtocol=https;AccountName=${funcStorageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${funcStorageAccount.listKeys().keys[0].value}'
-    FUNCTIONS_EXTENSION_VERSION: '~4'
-    FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-    APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
-    APPLICATIONINSIGHTS_CONNECTION_STRING: 'InstrumentationKey=${appInsightsInstrumentationKey}'
-    SCM_DO_BUILD_DURING_DEPLOYMENT: 'true'
-  }, functionSettings)
+    name: 'appsettings'
+    parent: functionApp
+    properties: union({
+            AzureWebJobsStorage: 'DefaultEndpointsProtocol=https;AccountName=${funcStorageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${funcStorageAccount.listKeys().keys[0].value}'
+            FUNCTIONS_EXTENSION_VERSION: '~4'
+            FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
+            APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
+            APPLICATIONINSIGHTS_CONNECTION_STRING: 'InstrumentationKey=${appInsightsInstrumentationKey}'
+            SCM_DO_BUILD_DURING_DEPLOYMENT: 'true'
+        }, functionSettings)
 }
 
+var defaultHostKey = listkeys('${functionApp.id}/host/default', '2016-08-01').functionKeys.default
+output functionAppKey string = defaultHostKey
 output functionAppName string = functionAppName
 output functionAppPrincipalId string = functionApp.identity.principalId
 output hostName string = functionApp.properties.defaultHostName
+output functionBaseUrl string = 'https://${functionApp.properties.defaultHostName}'

--- a/samples/Quickstart/infra/core.bicep
+++ b/samples/Quickstart/infra/core.bicep
@@ -7,6 +7,25 @@ param createWorkspace bool
 @description('Do you want to create a new FHIR Service or use an existing one?')
 param createFhirService bool
 
+@description('Flag to use API Management service instance')
+param useAPIM bool
+
+@description('The pricing tier of this API Management service')
+@allowed([ 'Consumption', 'Basic', 'Developer', 'Standard', 'Premium' ])
+param sku string = 'Consumption'
+
+@description('The instance size of this API Management service.')
+@allowed([0, 1, 2])
+param skuCount int = 0
+
+@description('The name of the owner of the API Management resource')
+@minLength(1)
+param publisherName string 
+
+@description('The email address of the owner of the API Management resource')
+@minLength(1)
+param publisherEmail string
+
 @description('Name of Azure Health Data Services workspace to deploy or use.')
 param workspaceName string
 
@@ -33,30 +52,30 @@ var tenantId  = subscription().tenantId
 
 @description('Deploy Azure Health Data Services and FHIR service')
 module fhir './fhir.bicep'= {
-  name: 'fhirDeploy'
-  params: {
-    createWorkspace: createWorkspace
-    createFhirService: createFhirService
-    workspaceName: workspaceName
-    fhirServiceName: fhirServiceName
-    location: location
-    tenantId: tenantId
-    appTags: appTags
-  }
+    name: 'fhirDeploy'
+    params: {
+        createWorkspace: createWorkspace
+        createFhirService: createFhirService
+        workspaceName: workspaceName
+        fhirServiceName: fhirServiceName
+        location: location
+        tenantId: tenantId
+        appTags: appTags
+    }
 }
 
-@description('Name for app insights resource used to monitor the Function App')
+@description('Name for app insights resource used to monitor the Function App and APIM')
 var appInsightsName = '${prefixName}-appins'
 
 @description('Deploy monitoring and logging')
 module monitoring './monitoring.bicep'= {
-  name: 'monitoringDeploy'
-  params: {
-    logAnalyticsName: logAnalyticsName
-    appInsightsName: appInsightsName
-    location: location
-    appTags: appTags
-  }
+    name: 'monitoringDeploy'
+    params: {
+        logAnalyticsName: logAnalyticsName
+        appInsightsName: appInsightsName
+        location: location
+        appTags: appTags
+    }
 }
 
 @description('Name for the App Service used to host the Function App.')
@@ -70,39 +89,78 @@ var funcStorName = '${replace(prefixName, '-', '')}funcsa'
 
 @description('Deploy Azure Function to run SDK custom operations')
 module function './azureFunction.bicep'= {
-  name: 'functionDeploy'
-  params: {
-    appServiceName: appServiceName
-    functionAppName: functionAppName
-    storageAccountName: funcStorName
-    location: location
-    appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
-    functionSettings: union({
-      AZURE_FhirServerUrl: 'https://${workspaceName}-${fhirServiceName}.fhir.azurehealthcareapis.com'
-      AZURE_InstrumentationKey: monitoring.outputs.appInsightsInstrumentationString
-    }, functionAppCustomSettings)
-    appTags: appTags
-  }
+    name: 'functionDeploy'
+    params: {
+        appServiceName: appServiceName
+        functionAppName: functionAppName
+        storageAccountName: funcStorName
+        location: location
+        appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+        functionSettings: union({
+                AZURE_FhirServerUrl: 'https://${workspaceName}-${fhirServiceName}.fhir.azurehealthcareapis.com'
+                AZURE_InstrumentationKey: monitoring.outputs.appInsightsInstrumentationString
+            }, functionAppCustomSettings)
+        appTags: appTags
+    }
 }
 
 @description('Setup identity connection between FHIR and the function app')
 module functionFhirIdentity './fhirIdentity.bicep'= {
-  name: 'fhirIdentity-function'
-  params: {
-    fhirId: fhir.outputs.fhirId
-    principalId: function.outputs.functionAppPrincipalId
-  }
+    name: 'fhirIdentity-function'
+    params: {
+        fhirId: fhir.outputs.fhirId
+        principalId: function.outputs.functionAppPrincipalId
+    }
 }
 
 @description('Setup identity connection between FHIR and the function app')
 module specifiedIdentity './fhirIdentity.bicep' =  [for principalId in  fhirContributorPrincipals: {
-  name: 'fhirIdentity-${principalId}'
-  params: {
-    fhirId: fhir.outputs.fhirId
-    principalId: principalId
-    principalType: 'User'
-  }
+    name: 'fhirIdentity-${principalId}'
+    params: {
+        fhirId: fhir.outputs.fhirId
+        principalId: principalId
+        principalType: 'User'
+    }
 }]
+
+@description('The name of the API Management service instance')
+var apiManagementServiceName = 'apim-${prefixName}'
+
+@description('Creates Azure API Management service instance')
+module apimService './apiManagement/apim.bicep' = if (useAPIM) {
+    name: 'apimService-deployment'
+    params: {
+        apiManagementServiceName: apiManagementServiceName
+        location: location
+        sku: sku
+        skuCount: skuCount
+        publisherName: publisherName
+        publisherEmail: publisherEmail
+        appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+        useAPIM:useAPIM
+    }
+}
+
+@description('Configures the API in the Azure API Management (APIM) service')
+module apimApi './apiManagement/apim-api.bicep' = if (useAPIM) {
+    name: 'apim-api-deployment'
+    params: {
+        name: useAPIM ? apimService.outputs.apimName : apiManagementServiceName
+        apiName: 'quickstart-api'
+        apiDisplayName: 'QuickStart API'
+        apiDescription: 'This is a QuickStart API'
+        functionAppUrl: function.outputs.functionBaseUrl
+        fhirServiceUrl: 'https://${workspaceName}-${fhirServiceName}.fhir.azurehealthcareapis.com'
+        functionAppKey: function.outputs.functionAppKey
+        apimServiceLoggerId: useAPIM ? apimService.outputs.serviceLoggerId : ''
+        useAPIM:useAPIM
+    }
+    dependsOn: [ apimService ]
+}
 
 output FhirServiceId string = fhir.outputs.fhirId
 output FhirServiceUrl string = 'https://${workspaceName}-${fhirServiceName}.fhir.azurehealthcareapis.com'
+output Azure_FunctionURL string = function.outputs.functionBaseUrl
+
+output APIM_HostName string = useAPIM ? '${apiManagementServiceName}.azure-api.net' : ''
+output APIM_GatewayUrl string = useAPIM ? 'https://${apiManagementServiceName}.azure-api.net' : ''

--- a/samples/Quickstart/infra/main.bicep
+++ b/samples/Quickstart/infra/main.bicep
@@ -21,6 +21,18 @@ param existingFhirServiceName string = ''
 @description('Name of your existing resource group (leave blank to create a new one)')
 param existingResourceGroupName string = ''
 
+@description('Flag to use API Management service instance')
+param useAPIM bool = true
+
+@description('Name of the owner of the API Management resource')
+@minLength(1)
+param publisherName string 
+
+@description('Email of the owner of the API Management resource')
+@minLength(1)
+param publisherEmail string
+
+
 var envRandomString = toLower(uniqueString(subscription().id, name, existingResourceGroupName, location))
 var nameShort = length(name) > 11 ? substring(name, 0, 11) : name
 var resourcePrefix = '${nameShort}-${substring(envRandomString, 0, 5)}'
@@ -56,6 +68,9 @@ module template 'core.bicep'= if (createResourceGroup) {
     location: location
     appTags: appTags
     fhirContributorPrincipals: [principalId]
+    useAPIM: useAPIM
+    publisherName:publisherName
+    publisherEmail:publisherEmail
   }
 }
 
@@ -71,9 +86,17 @@ module existingResourceGrouptemplate 'core.bicep'= if (!createResourceGroup) {
     location: location
     appTags: appTags
     fhirContributorPrincipals: [principalId]
+    useAPIM: useAPIM
+    publisherName:publisherName
+    publisherEmail:publisherEmail
   }
 }
 
 // These map to user secrets for local execution of the program
 output LOCATION string = location
 output FhirServerUrl string = createResourceGroup ? template.outputs.FhirServiceUrl : existingResourceGrouptemplate.outputs.FhirServiceUrl
+output Azure_FunctionURL string = createResourceGroup ? template.outputs.Azure_FunctionURL : existingResourceGrouptemplate.outputs.Azure_FunctionURL
+output USE_APIM bool = useAPIM
+output APIM_HostName string = useAPIM ? template.outputs.APIM_HostName:''
+output APIM_GatewayUrl string = useAPIM ? template.outputs.APIM_GatewayUrl:''
+

--- a/samples/Quickstart/infra/main.parameters.json
+++ b/samples/Quickstart/infra/main.parameters.json
@@ -1,24 +1,27 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
-    "parameters": {
-        "name": {
-            "value": "${AZURE_ENV_NAME}"
-        },
-        "location": {
-            "value": "${AZURE_LOCATION}"
-        },
-        "principalId": {
-            "value": "${AZURE_PRINCIPAL_ID}"
-        },
-        "existingResourceGroupName": {
-            "value": ""
-        },
-        "existingAzureHealthDataServicesWorkspaceName": {
-            "value": ""
-        },
-        "existingFhirServiceName": {
-            "value": ""
-        }
+  "parameters": {
+    "name": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    },
+    "existingResourceGroupName": {
+      "value": ""
+    },
+    "existingAzureHealthDataServicesWorkspaceName": {
+      "value": ""
+    },
+    "existingFhirServiceName": {
+      "value": ""
+    },
+    "useAPIM": {
+      "value": "${USE_APIM=true}"
     }
+  }
 }


### PR DESCRIPTION

## Description
-  Added APIM to Toolkit Quickstart, APIM will be used for Fhir Service and Function App endpoints 
- Disable Basic Auth for Toolkit Quickstart

## Related issues
-  New-Feature- 102337
-  New-Feature- 103038

## Testing
-  Tested APIM after deployment, did testing for Quickstart function app and FHIR endpoints through APIM.
-  After deployment of Quickstart function app ensured that the basic auth is turned off.
## Reviewer Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Tag the PR with the type of update: **Bug**, **New-Sample**, **Enhancement**, or **New-Feature**
- [ ] CI is green before merge
