### PR TITLE
Replace text/plain from header collection

### DIFF
--- a/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
+++ b/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -40,13 +41,14 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
 
             foreach (KeyValuePair<string, IEnumerable<string>> header in req.Headers)
             {
-                if (HttpMessageExtensions.ContentHeaderNames.Any(x => string.Equals(x, header.Key, StringComparison.OrdinalIgnoreCase)))
+                if (string.Equals(header.Key, Net.Http.Headers.HeaderNames.ContentType, StringComparison.OrdinalIgnoreCase))
                 {
-                    message.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    // only include the first value for Content-Type
+                    message.Content.Headers.ContentType = new MediaTypeHeaderValue(header.Value.First());
                 }
                 else
                 {
-                    message.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    message.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
                 }
             }
 


### PR DESCRIPTION
## Description
This change corrects the issue described in #111 where the AzureFunctionExtensions.ConvertToHttpRequestMesssage where text/plain is incorrectly added to the Content-Type header collection.

## Related issues
Addresses #111 .

## Reviewer Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Tag the PR with the type of update: **Bug**, **New-Sample**, **Enhancement**, or **New-Feature**
- [ ] CI is green before merge
