### PR TITLE
Remove secrets from Quickstart bicep provisioning

### DIFF
--- a/samples/Quickstart/infra/apiManagement/apim-api.bicep
+++ b/samples/Quickstart/infra/apiManagement/apim-api.bicep
@@ -16,8 +16,11 @@ param apiDescription string
 @description('Absolute URL of the backend function app for implementing this API.')
 param functionAppUrl string
 
-@description('Default Key of the function app for implementing this API.')
-param functionAppKey string
+@description('Function App Name')
+param functionAppName string
+//@description('Default Key of the function app for implementing this API.')
+//@secure()
+//param functionAppKey string
 
 @description('Absolute URL of the backend Fhir Service for implementing this API.')
 param fhirServiceUrl string
@@ -32,11 +35,18 @@ var fhirApiPolicyContent = replace(loadTextContent('policies/apim-fhir-api-polic
 
 var QuickStartPolicyContent = replace(loadTextContent('policies/apim-quickstart-api-policy.xml'), '{functionAppUrl}', functionAppUrl)
 
-var QuickStartPolicy = replace(QuickStartPolicyContent,'{funDefaultKey}',functionAppKey)
+
 
 resource apimService 'Microsoft.ApiManagement/service@2021-08-01' existing = if(useAPIM) {
     name: name
 }
+
+resource functionApp 'Microsoft.Web/sites@2021-03-01' existing = {
+    name: functionAppName
+}
+
+var functionAppKey = listkeys('${functionApp.id}/host/default', '2016-08-01').functionKeys.default
+var QuickStartPolicy = replace(QuickStartPolicyContent,'{funDefaultKey}',functionAppKey)
 
 resource quickStartApi 'Microsoft.ApiManagement/service/apis@2021-12-01-preview' = if(useAPIM) {
     name: apiName

--- a/samples/Quickstart/infra/azureFunction.bicep
+++ b/samples/Quickstart/infra/azureFunction.bicep
@@ -93,9 +93,6 @@ resource functionAppSettings 'Microsoft.Web/sites/config@2020-12-01' = {
         }, functionSettings)
 }
 
-var defaultHostKey = listkeys('${functionApp.id}/host/default', '2016-08-01').functionKeys.default
-output functionAppKey string = defaultHostKey
-output functionAppName string = functionAppName
 output functionAppPrincipalId string = functionApp.identity.principalId
 output hostName string = functionApp.properties.defaultHostName
 output functionBaseUrl string = 'https://${functionApp.properties.defaultHostName}'

--- a/samples/Quickstart/infra/core.bicep
+++ b/samples/Quickstart/infra/core.bicep
@@ -165,7 +165,7 @@ module apimApi './apiManagement/apim-api.bicep' = if (useAPIM) {
         apiDescription: 'This is a QuickStart API'
         functionAppUrl: function.outputs.functionBaseUrl
         fhirServiceUrl: 'https://${workspaceName}-${fhirServiceName}.fhir.azurehealthcareapis.com'
-        functionAppKey: function.outputs.functionAppKey
+        functionAppName: functionAppName
         apimServiceLoggerId: useAPIM ? apimService.outputs.serviceLoggerId : ''
         useAPIM:useAPIM
     }


### PR DESCRIPTION
## Description
Defender for Azure is getting triggered by secrets, specifically the default Function App access key, appearing in the inputs and outputs of the bicep provisioning.

This PR removes those secrets and instead uses a bicep function to lookup with existing resource's access key.

## Related issues
Resolves #125 .

## Testing
This change was tested by provisioning the quickstart with the 'AZD' CLI and confirming the absence of secret values from the deployment logs.

## Reviewer Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Tag the PR with the type of update: **Bug**, **New-Sample**, **Enhancement**, or **New-Feature**
- [ ] CI is green before merge
