### PR TITLE
Resolve Content-Type parsing issue

### DIFF
--- a/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
+++ b/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
@@ -46,8 +46,7 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
                     if (string.Equals(header.Key, Net.Http.Headers.HeaderNames.ContentType, StringComparison.OrdinalIgnoreCase))
                     {
                         // only include the first value for Content-Type
-                        var contentTypeHeaderValue = header.Value.First();
-                        message.Content.Headers.ContentType = contentTypeHeaderValue.ParseMediaType();
+                        message.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(header.Value.First());
                     }
                     else
                     {
@@ -165,24 +164,6 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
             JsonWebToken jwt = new(header);
             ClaimsIdentity identity = new(jwt.Claims);
             return new ClaimsPrincipal(identity);
-        }
-
-        public static MediaTypeHeaderValue ParseMediaType(this string headerValue)
-        {
-            var parts = headerValue.Split(';');
-            string charSet = null;
-
-            if (parts.Length > 1)
-            {
-                var charsetPart = parts[1].Trim();
-                if (charsetPart.StartsWith("charset=", StringComparison.OrdinalIgnoreCase))
-                {
-                    charSet = charsetPart.Substring("charset=".Length).Trim();
-                }
-            }
-
-            // Use the MediaTypeHeaderValue constructor to create the object
-            return new MediaTypeHeaderValue(parts[0].Trim(), charSet);
         }
     }
 }

--- a/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
+++ b/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
@@ -43,6 +43,7 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
             {
                 if (HttpMessageExtensions.ContentHeaderNames.Any(x => string.Equals(x, header.Key, StringComparison.OrdinalIgnoreCase)))
                 {
+                    message.Content ??= new ByteArrayContent(Array.Empty<byte>());
                     if (string.Equals(header.Key, Net.Http.Headers.HeaderNames.ContentType, StringComparison.OrdinalIgnoreCase))
                     {
                         // only include the first value for Content-Type

--- a/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
+++ b/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
@@ -46,7 +46,8 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
                     if (string.Equals(header.Key, Net.Http.Headers.HeaderNames.ContentType, StringComparison.OrdinalIgnoreCase))
                     {
                         // only include the first value for Content-Type
-                        message.Content.Headers.ContentType = new MediaTypeHeaderValue(header.Value.First());
+                        var contentTypeHeaderValue = header.Value.First();
+                        message.Content.Headers.ContentType = contentTypeHeaderValue.ParseMediaType();
                     }
                     else
                     {
@@ -164,6 +165,24 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
             JsonWebToken jwt = new(header);
             ClaimsIdentity identity = new(jwt.Claims);
             return new ClaimsPrincipal(identity);
+        }
+
+        public static MediaTypeHeaderValue ParseMediaType(this string headerValue)
+        {
+            var parts = headerValue.Split(';');
+            string charSet = null;
+
+            if (parts.Length > 1)
+            {
+                var charsetPart = parts[1].Trim();
+                if (charsetPart.StartsWith("charset=", StringComparison.OrdinalIgnoreCase))
+                {
+                    charSet = charsetPart.Substring("charset=".Length).Trim();
+                }
+            }
+
+            // Use the MediaTypeHeaderValue constructor to create the object
+            return new MediaTypeHeaderValue(parts[0].Trim(), charSet);
         }
     }
 }


### PR DESCRIPTION
Resolves #128

- Improves Content-Type header value parsing via the [MediaTypeHeaderValue.Parse(string)](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.headers.mediatypeheadervalue.parse?view=net-8.0#system-net-http-headers-mediatypeheadervalue-parse(system-string)) method
- Adds test to avoid regression
- Also resolves edge-case whereby `Request.Content` is null when attempting to set content headers (see null-coalescing assignment)