### PR TITLE
Race condition in OperationContext

### DIFF
--- a/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/OperationContext.cs
+++ b/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/OperationContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
             Request = message;
             properties = new Dictionary<string, string>();
             headers = new HttpCustomHeaderCollection();
-            SetContentAsync(message).GetAwaiter();
+            SetContentAsync(message).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
             Request = message;
             properties = new Dictionary<string, string>();
             this.headers = headers;
-            SetContentAsync(message).GetAwaiter();
+            SetContentAsync(message).GetAwaiter().GetResult();
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
To fix the Race condition in OperationContext - SetContentAsync fails while reading large payloads.

## Related issues
Addresses [issue #140 ].

## Testing
We ran the sample on Docker to reproduce the issue of failure while reading large payloads, but the issue did not reproduce. The operation context waits until the entire payload is read before proceeding to the binding process.

## Reviewer Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Tag the PR with the type of update: **Bug**, **New-Sample**, **Enhancement**, or **New-Feature**
- [ ] CI is green before merge
