### PR TITLE
OperationContext creation avoid sync-over-async 

### DIFF
--- a/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/OperationContext.cs
+++ b/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/OperationContext.cs
@@ -29,29 +29,14 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
         /// Creates an instance of OperationContext
         /// </summary>
         /// <param name="message">Initial http request message</param>
-        public OperationContext(HttpRequestMessage message)
-        {
-            _ = message ?? throw new ArgumentNullException(nameof(message));
-
-            Request = message;
-            properties = new Dictionary<string, string>();
-            headers = new HttpCustomHeaderCollection();
-            SetContentAsync(message).GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Creates an instance of OperationContext
-        /// </summary>
-        /// <param name="message">Initial http request message</param>
         /// <param name="headers">Initial header collection</param>
-        public OperationContext(HttpRequestMessage message, IHttpCustomHeaderCollection headers)
+        private OperationContext(HttpRequestMessage message, IHttpCustomHeaderCollection headers)
         {
             _ = message ?? throw new ArgumentNullException(nameof(message));
 
             Request = message;
             properties = new Dictionary<string, string>();
             this.headers = headers;
-            SetContentAsync(message).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -97,6 +82,16 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
         /// Gets or sets an exception when a fatal error occurs processing the operation context
         /// </summary>
         public Exception Error { get; set; }
+
+        public static async Task<OperationContext> CreateAsync(HttpRequestMessage message) =>
+            await CreateAsync(message, new HttpCustomHeaderCollection());
+
+        public static async Task<OperationContext> CreateAsync(HttpRequestMessage message, IHttpCustomHeaderCollection headers)
+        {
+            OperationContext context = new(message, headers);
+            await context.SetContentAsync(message);
+            return context;
+        }
 
         /// <summary>
         /// Updates the request URI and method.

--- a/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/WebPipeline.cs
+++ b/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/WebPipeline.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
 
             try
             {
-                _context = new(request, _headers);
+                _context = await OperationContext.CreateAsync(request, _headers);
 
                 _context = await ExecuteFiltersAsync(_inputFilters, _context);
 
@@ -222,7 +222,7 @@ namespace Microsoft.AzureHealth.DataServices.Pipelines
 
                         logger?.LogInformation("Pipeline {Name}-{Id} channel {ChannelName}-{ChannelId} is in state {State}.", Name, Id, channel.Name, channel.Id, channel.State);
 
-                        var contentType = context.Request.Content?.Headers.ContentType.ToString();
+                        var contentType = context.Request.Content?.Headers.ContentType?.ToString();
                         contentType ??= context.Request.Headers.Accept.ToString();
 
                         await channel.SendAsync(context.Content, new object[] { contentType });

--- a/src/Microsoft.AzureHealth.DataServices.Storage/Microsoft.AzureHealth.DataServices.Storage.csproj
+++ b/src/Microsoft.AzureHealth.DataServices.Storage/Microsoft.AzureHealth.DataServices.Storage.csproj
@@ -5,6 +5,7 @@
     <PackageId>Microsoft.AzureHealth.DataServices.Storage</PackageId>
     <AssemblyName>Microsoft.AzureHealth.DataServices.Storage</AssemblyName>
     <Description>Storage library to assist with creating custom operations for Azure Health Data Services.</Description>
+    <WarningsNotAsErrors>NU1903</WarningsNotAsErrors> <!-- To be able to restore Microsoft.Extensions.Caching.Memory -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.AzureHealth.DataServices.Tests/Core/OperationContextTests.cs
+++ b/tests/Microsoft.AzureHealth.DataServices.Tests/Core/OperationContextTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AzureHealth.DataServices.Pipelines;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -10,7 +11,7 @@ namespace Microsoft.AzureHealth.DataServices.Tests.Core
     public class OperationContextTests
     {
         [TestMethod]
-        public void OperationContext_UpdateUri_Test()
+        public async Task OperationContext_UpdateUri_Test()
         {
             string content = "content";
             string uriString = "https://example.org/fhir/Patient/1";
@@ -18,7 +19,7 @@ namespace Microsoft.AzureHealth.DataServices.Tests.Core
             HttpMethod expectedMethod = HttpMethod.Post;
 
             HttpRequestMessage request = new(HttpMethod.Get, new Uri(uriString));
-            OperationContext context = new(request);
+            OperationContext context = await OperationContext.CreateAsync(request);
             context.UpdateFhirRequestUri(expectedMethod, "fhir", "Patient", "2");
             context.ContentString = content;
 
@@ -28,14 +29,14 @@ namespace Microsoft.AzureHealth.DataServices.Tests.Core
         }
 
         [TestMethod]
-        public void OperationContext_Properties_Test()
+        public async Task OperationContext_Properties_Test()
         {
             string propKey = "test";
             string propValue = "value";
             string uriString = "https://example.org/fhir/Patient/1";
 
             HttpRequestMessage request = new(HttpMethod.Get, new Uri(uriString));
-            OperationContext context = new(request);
+            OperationContext context = await OperationContext.CreateAsync(request);
             context.Properties.Add(propKey, propValue);
             string actualValue = context.Properties[propKey];
             Assert.AreEqual(propValue, actualValue, "Property mismatch.");

--- a/tests/Microsoft.AzureHealth.DataServices.Tests/Headers/DelayedHttpContent.cs
+++ b/tests/Microsoft.AzureHealth.DataServices.Tests/Headers/DelayedHttpContent.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AzureHealth.DataServices.Headers;
+
+/// <summary>
+/// Purpose of this mock httpContext to mimic situation when creation of httprequest content takes a lot of time.
+/// </summary>
+/// <param name="content">content</param>
+/// <param name="miliseconds">how long to delay before creating content</param>
+public class DelayedHttpContent(string content, int miliseconds = 1000) : HttpContent
+{
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+    {
+        await Task.Delay(miliseconds);
+        stream.Write(Encoding.UTF8.GetBytes(content));
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = content.Length;
+        return true;
+    }
+}


### PR DESCRIPTION
## Description
Enhances `OperationContext` creation.

 Currently OperationContext is created using constructor. This prevents executing async code. But during construction of `OperationContext` there is a need to execute an asynchronous operation to read request content
```cs
await message.Content.ReadAsByteArrayAsync();
```
This requires to fallback to `sync-over-async` anti-pattern in `OperationContext` constructor:
```cs
SetContentAsync(message).GetAwaiter().GetResult();
```
This change introduces static asynchronous factory methods  to create `OperationContext`:
```cs
public static async Task<OperationContext> CreateAsync(HttpRequestMessage message);
public static async Task<OperationContext> CreateAsync(HttpRequestMessage message, IHttpCustomHeaderCollection headers);
```
They are used through the codebase to create `OperationContext` instances:
```cs
 _context = await OperationContext.CreateAsync(request, _headers);
```
### Additional notes:
Needed to add this exception to the rule to be able to build the solution.
```xml
<WarningsNotAsErrors>NU1903</WarningsNotAsErrors> <!-- To be able to restore Microsoft.Extensions.Caching.Memory -->
```
Didn't want to update the version of this dependency, because I think this is out of the current improvement scope.
## Related issues
Addresses issue #140.

## Testing
Added WebPipeline test that emulates long-running request message content reading (that allows to kick-in scenario described in issue #140)

## Reviewer Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Tag the PR with the type of update: **Bug**, **New-Sample**, **Enhancement**, or **New-Feature**
- [ ] CI is green before merge
