### PR TITLE
Personal/v shahamad/ft app insight connection string changes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.14.1" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(RuntimePackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="$(RuntimePackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(RuntimePackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(RuntimePackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(RuntimePackageVersion)" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.301",
+        "version": "8.0.405",
         "rollForward": "latestFeature"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.405",
+        "version": "8.0.308",
         "rollForward": "latestFeature"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.308",
+        "version": "8.0.112",
         "rollForward": "latestFeature"
     }
 }

--- a/samples/Quickstart/infra/apiManagement/apim.bicep
+++ b/samples/Quickstart/infra/apiManagement/apim.bicep
@@ -4,7 +4,7 @@ param sku string
 param skuCount int
 param publisherName string
 param publisherEmail string
-param appInsightsInstrumentationKey string
+param appInsightsConnectionString string
 param useAPIM bool
 param appInsightsName string
 param appInsightsExternalId string = '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/microsoft.insights/components/${appInsightsName}'
@@ -30,8 +30,7 @@ resource apim 'Microsoft.ApiManagement/service@2021-12-01-preview' = if (useAPIM
     properties: {
       loggerType: 'applicationInsights'
       credentials: {
-        appInsightsInstrumentationKey: appInsightsInstrumentationKey
-        instrumentationKey: appInsightsInstrumentationKey
+        connectionString: appInsightsConnectionString
       }
       isBuffered: true
       resourceId: appInsightsExternalId

--- a/samples/Quickstart/infra/azureFunction.bicep
+++ b/samples/Quickstart/infra/azureFunction.bicep
@@ -1,7 +1,7 @@
 param storageAccountName string
 param appServiceName string
 param functionAppName string
-param appInsightsInstrumentationKey string
+param appInsightsConnectionString string
 param location string
 param functionSettings object = {}
 param appTags object = {}
@@ -91,8 +91,7 @@ resource functionAppSettings 'Microsoft.Web/sites/config@2022-09-01' = {
             AzureWebJobsStorage__accountname: storageAccountName
             FUNCTIONS_EXTENSION_VERSION: '~4'
             FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-            APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
-            APPLICATIONINSIGHTS_CONNECTION_STRING: 'InstrumentationKey=${appInsightsInstrumentationKey}'
+            APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
             SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
             ENABLE_ORYX_BUILD: 'false'
         }, functionSettings)

--- a/samples/Quickstart/infra/core.bicep
+++ b/samples/Quickstart/infra/core.bicep
@@ -109,10 +109,10 @@ module function './azureFunction.bicep'= {
         functionAppName: functionAppName
         storageAccountName: funcStorName
         location: location
-        appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+        appInsightsConnectionString: monitoring.outputs.appInsightsInstrumentationString
         functionSettings: union({
                 AZURE_FhirServerUrl: 'https://${workspaceName}-${fhirServiceName}.fhir.azurehealthcareapis.com'
-                AZURE_InstrumentationKey: monitoring.outputs.appInsightsInstrumentationString
+                AZURE_AppInsightsConnectionString: monitoring.outputs.appInsightsInstrumentationString
             }, functionAppCustomSettings)
         appTags: appTags
     }
@@ -150,7 +150,7 @@ module apimService './apiManagement/apim.bicep' = if (useAPIM) {
         skuCount: skuCount
         publisherName: publisherName
         publisherEmail: publisherEmail
-        appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+        appInsightsConnectionString: monitoring.outputs.appInsightsInstrumentationString
         useAPIM:useAPIM
         appInsightsName:appInsightsName
     }

--- a/samples/Quickstart/infra/monitoring.bicep
+++ b/samples/Quickstart/infra/monitoring.bicep
@@ -50,6 +50,4 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02-preview' = {
   }
   tags: appTags
 }
-
-output appInsightsInstrumentationKey string = appInsights.properties.InstrumentationKey
 output appInsightsInstrumentationString string= appInsights.properties.ConnectionString

--- a/samples/Quickstart/src/Configuration/MyServiceConfig.cs
+++ b/samples/Quickstart/src/Configuration/MyServiceConfig.cs
@@ -4,6 +4,6 @@
     {
         public Uri FhirServerUrl { get; set; }
 
-        public string InstrumentationKey { get; set; }
+        public string AppInsightsConnectionString { get; set; }
     }
 }

--- a/samples/Quickstart/src/Program.cs
+++ b/samples/Quickstart/src/Program.cs
@@ -36,10 +36,10 @@ internal static class Program
             .ConfigureFunctionsWorkerDefaults()
             .ConfigureServices(services =>
             {
-                if (config.InstrumentationKey != null)
+                if (config.AppInsightsConnectionString != null)
                 {
-                    services.UseAppInsightsLogging(config.InstrumentationKey, LogLevel.Information);
-                    services.UseTelemetry(config.InstrumentationKey);
+                    services.UseAppInsightsLogging(config.AppInsightsConnectionString, LogLevel.Information);
+                    services.UseTelemetry(config.AppInsightsConnectionString);
                 }
 
                 // Setup custom headers for use in an Input Filter

--- a/samples/UseCaseSamples/ModifyCapabilityStatement/infra/apiManagement/apim.bicep
+++ b/samples/UseCaseSamples/ModifyCapabilityStatement/infra/apiManagement/apim.bicep
@@ -4,7 +4,7 @@ param sku string
 param skuCount int
 param publisherName string
 param publisherEmail string
-param appInsightsInstrumentationKey string
+param appInsightsConnectionString string
 param useAPIM bool
 param appInsightsName string
 param appInsightsExternalId string = '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/microsoft.insights/components/${appInsightsName}'
@@ -30,8 +30,7 @@ resource apim 'Microsoft.ApiManagement/service@2021-12-01-preview' = if (useAPIM
     properties: {
       loggerType: 'applicationInsights'
       credentials: {
-        appInsightsInstrumentationKey: appInsightsInstrumentationKey
-        instrumentationKey: appInsightsInstrumentationKey
+        connectionString: appInsightsConnectionString
       }
       isBuffered: true
       resourceId: appInsightsExternalId

--- a/samples/UseCaseSamples/ModifyCapabilityStatement/infra/azureFunction.bicep
+++ b/samples/UseCaseSamples/ModifyCapabilityStatement/infra/azureFunction.bicep
@@ -26,11 +26,11 @@ resource hostingPlan 'Microsoft.Web/serverfarms@2021-03-01' = {
   location: location
   kind: 'functionapp'
   sku: {
-    name: 'Y1'
-    tier: 'Dynamic'
+    name: 'S1'
+    tier: 'Standard'
   }
   properties: {
-    reserved: true
+    //reserved: true
   }
   tags: appTags
 }
@@ -55,6 +55,7 @@ resource functionApp 'Microsoft.Web/sites@2021-03-01' = {
             netFrameworkVersion: 'v8.0'
             //linuxFxVersion: 'dotnet-isolated|8.0'
             //use32BitWorkerProcess: false
+            alwaysOn:true
         }
     }
 

--- a/samples/UseCaseSamples/ModifyCapabilityStatement/infra/azureFunction.bicep
+++ b/samples/UseCaseSamples/ModifyCapabilityStatement/infra/azureFunction.bicep
@@ -1,7 +1,7 @@
 param storageAccountName string
 param appServiceName string
 param functionAppName string
-param appInsightsInstrumentationKey string
+param appInsightsConnectionString string
 param location string
 param functionSettings object = {}
 param appTags object = {}
@@ -90,8 +90,7 @@ resource functionAppSettings 'Microsoft.Web/sites/config@2022-09-01' = {
             AzureWebJobsStorage__accountname: storageAccountName
             FUNCTIONS_EXTENSION_VERSION: '~4'
             FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-            APPINSIGHTS_INSTRUMENTATIONKEY: appInsightsInstrumentationKey
-            APPLICATIONINSIGHTS_CONNECTION_STRING: 'InstrumentationKey=${appInsightsInstrumentationKey}'
+            APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
             SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
             ENABLE_ORYX_BUILD: 'false'
         }, functionSettings)

--- a/samples/UseCaseSamples/ModifyCapabilityStatement/infra/core.bicep
+++ b/samples/UseCaseSamples/ModifyCapabilityStatement/infra/core.bicep
@@ -95,10 +95,10 @@ module function './azureFunction.bicep'= {
         functionAppName: functionAppName
         storageAccountName: funcStorName
         location: location
-        appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+        appInsightsConnectionString: monitoring.outputs.appInsightsInstrumentationString
         functionSettings: union({
                 AZURE_FhirServerUrl: 'https://${workspaceName}-${fhirServiceName}.fhir.azurehealthcareapis.com'
-                AZURE_InstrumentationKey: monitoring.outputs.appInsightsInstrumentationString
+                AZURE_AppInsightsConnectionString: monitoring.outputs.appInsightsInstrumentationString
             }, functionAppCustomSettings)
         appTags: appTags
     }
@@ -136,7 +136,7 @@ module apimService './apiManagement/apim.bicep' = if (useAPIM) {
         skuCount: skuCount
         publisherName: publisherName
         publisherEmail: publisherEmail
-        appInsightsInstrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+        appInsightsConnectionString: monitoring.outputs.appInsightsInstrumentationString
         useAPIM:useAPIM
         appInsightsName:appInsightsName
     }

--- a/samples/UseCaseSamples/ModifyCapabilityStatement/infra/monitoring.bicep
+++ b/samples/UseCaseSamples/ModifyCapabilityStatement/infra/monitoring.bicep
@@ -51,5 +51,4 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02-preview' = {
   tags: appTags
 }
 
-output appInsightsInstrumentationKey string = appInsights.properties.InstrumentationKey
 output appInsightsInstrumentationString string= appInsights.properties.ConnectionString

--- a/samples/UseCaseSamples/ModifyCapabilityStatement/src/Configuration/MyServiceConfig.cs
+++ b/samples/UseCaseSamples/ModifyCapabilityStatement/src/Configuration/MyServiceConfig.cs
@@ -4,6 +4,6 @@
     {
         public Uri FhirServerUrl { get; set; }
 
-        public string InstrumentationKey { get; set; }
+        public string AppInsightsConnectionString { get; set; }
     }
 }

--- a/samples/UseCaseSamples/ModifyCapabilityStatement/src/Program.cs
+++ b/samples/UseCaseSamples/ModifyCapabilityStatement/src/Program.cs
@@ -36,10 +36,10 @@ internal static class Program
             .ConfigureFunctionsWorkerDefaults()
             .ConfigureServices(services =>
             {
-                if (config.InstrumentationKey != null)
+                if (config.AppInsightsConnectionString != null)
                 {
-                    services.UseAppInsightsLogging(config.InstrumentationKey, LogLevel.Information);
-                    services.UseTelemetry(config.InstrumentationKey);
+                    services.UseAppInsightsLogging(config.AppInsightsConnectionString, LogLevel.Information);
+                    services.UseTelemetry(config.AppInsightsConnectionString);
                 }
 
                 // Setup custom headers for use in an Input Filter

--- a/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
+++ b/src/Microsoft.AzureHealth.DataServices.Core/Pipelines/AzureFunctionExtensions.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Mime;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker.Http;


### PR DESCRIPTION
Transition to using connection strings for data ingestion


1. It contains changes to use app insights connection string instead of instrumentation key
2. SDK version in global.json is changed to the one which is available in code QI runner.
3. Changed the configurations for function app deployments for the usecase sample . 


https://microsofthealth.visualstudio.com/Health/_workitems/edit/148419